### PR TITLE
Add coffeescript support

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function(sails) {
       // Find all jobs
       var jobs = require('include-all')({
           dirname     : sails.config.appPath + '/' + config.jobsDirectory,
-          filter      : /(.+Job).+$/,
+          filter      : /(.+Job).(?:js|coffee)$/,
           excludeDirs : /^\.(git|svn)$/,
           optional    : true
       });

--- a/index.js
+++ b/index.js
@@ -57,10 +57,23 @@ module.exports = function(sails) {
 
       global[config.globalJobsObjectName] = agenda;
 
+      // Enable jobs using coffeescript
+      try {
+        require('coffee-script/register');
+      } catch(e0) {
+        try {
+          var path = require('path');
+          var appPath = sails.config.appPath || process.cwd();
+          require(path.join(appPath, 'node_modules/coffee-script/register'));
+        } catch(e1) {
+          sails.log.verbose('Please run `npm install coffee-script` to use coffescript (skipping for now)');
+        }
+      }
+
       // Find all jobs
       var jobs = require('include-all')({
           dirname     : sails.config.appPath + '/' + config.jobsDirectory,
-          filter      : /(.+Job)\.js$/,
+          filter      : /(.+Job).+$/,
           excludeDirs : /^\.(git|svn)$/,
           optional    : true
       });


### PR DESCRIPTION
I have used the method that [sails](https://github.com/balderdashy/sails/blob/a2ac23fa178369bd1ca86165a6148f0ec7d2e98e/lib/hooks/moduleloader/index.js#L43-L54) uses to enable coffeescript support for jobs.
