### PR TITLE
Feature/cron support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+Copyright (c) 2016 Sri Hari Raju Penmatsa
+The License to this work is same as that of the original it is derived from
+
+---------------ORIGINAL LICENCE----------------
 The MIT License (MIT)
 
 Copyright (c) 2015 Vincent Buzzano

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# sails-hook-jobs
+# sails-hook-agenda
 
-Sails JS hook to add async background jobs.
+Sails JS hook to add async background agenda.
 
 This project use "agenda" as the job engine  
  - github: https://github.com/rschmukler/agenda
@@ -12,7 +12,7 @@ Agenda is a light-weight job scheduling library for Node.js. And it's use mongod
 
 If your are using sails 0.11.x you just need to install it.
 
-    npm install sails-hook-jobs
+    npm install sails-hook-agenda
 
 for sails 0.10.x, create a folder 'jobs' in your api/hooks folder and copy index.js from this project.
 
@@ -24,10 +24,9 @@ Copy this configurations file and save it to config/jobs.js
      * Default jobs configuration
      * (sails.config.jobs)
      *
-     * For more information using jobs in your app, check out:
+     * For more information using agenda in your app, check out:
      * https://github.com/vbuzzano/sails-hook-jobs
      */
-    
     module.exports.jobs = {
     
       // Where are jobs files

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This project use "agenda" as the job engine
 
 Agenda is a light-weight job scheduling library for Node.js. And it's use mongodb.
 
+### FORKED FROM [sails-hook-jobs](https://github.com/vbuzzano/sails-hook-jobs)
+This fork has support for **cron strings** which is not available in sails-hook-jobs.
+The all cron strings supported by agenda are available now.
+
+
+
 ## Install
 
 If your are using sails 0.11.x you just need to install it.
@@ -62,6 +68,7 @@ Simply create a js file (name ending with Job.js, eg: myJob.js) in api/jobs or i
             //disabled: false,
     
             // method can be 'every <interval>', 'schedule <when>' or now
+            //frequency supports cron strings
             frequency: 'every 5 seconds',
     
             // Jobs options

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var CronParser = require('./node_modules/cron/lib/cron-parser.js');
+var CronParser = require('cron/lib/cron-parser');
 var cronParser = new CronParser;
 
 module.exports = function(sails) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-var CronParser = require('cron/lib/cron-parser');
-var cronParser = new CronParser;
+var CronJob = require('cron').CronJob;
 
 module.exports = function(sails) {
 
@@ -144,20 +143,22 @@ module.exports = function(sails) {
                 var when = freq.substr(9).trim();
                 agenda.schedule(when, _name, _job.data);
                 log += " and scheduled " + when;
+                //No error is thrown, so continue with creating an agenda.
               } else if (freq === 'now') {
                 agenda.now(_name, _job.data);
                 log += " and started";
               } else {
                 //last test for freq to see if its a cron string.
                 try{
-                  cronParser.parse(freq);
-                  // cron parsing successful. sending to agenda.every
+                  //This will throw an error when freq is not a cron string
+                  new CronJob(freq);
+                  //No error is thrown, so continue with creating an agenda.
                   agenda.every(freq, _name, _job.data);
-                  log += " and scheduled for this/these crontime(s)";
+                  log += " and scheduled for this(these) crontime(s) "+ "freq";
                 }catch(err){
                   //failed to parse the string as a cronTime(s)
                   error = true;
-                  log += ". But the frequency, " + freq + " is not supported";
+                  log += ". But the frequency, '" + freq + "' is not supported";
                 }
               }
             }

--- a/index.js
+++ b/index.js
@@ -143,7 +143,6 @@ module.exports = function(sails) {
                 var when = freq.substr(9).trim();
                 agenda.schedule(when, _name, _job.data);
                 log += " and scheduled " + when;
-                //No error is thrown, so continue with creating an agenda.
               } else if (freq === 'now') {
                 agenda.now(_name, _job.data);
                 log += " and started";

--- a/package.json
+++ b/package.json
@@ -21,11 +21,22 @@
   },
   "dependencies": {
     "agenda": "^0.6.26",
+    "cron": "^1.1.0",
     "include-all": "^0.1.6",
     "lodash": "^2.4.1"
   },
   "devDependencies": {
     "sails": "~0.11.0"
   },
-  "keywords": [ "sails", "sailsjs", "agenda", "jobs", "hook", "coffee", "schedule", "background", "process" ]
+  "keywords": [
+    "sails",
+    "sailsjs",
+    "agenda",
+    "jobs",
+    "hook",
+    "coffee",
+    "schedule",
+    "background",
+    "process"
+  ]
 }


### PR DESCRIPTION
[agenda](https://github.com/rschmukler/agenda) supports cron strings for `agenda.every()`. But sails-hook-jobs doesn't.

It would be useful to have frequency accept _cron strings_ as well.

**Changes**
- A new dependency is added. [node-cron](https://github.com/ncb000gt/node-cron) (aka cron in npm). This is used by [agenda](). So, thought it would be logical to have this check the validity of the cron string.
- Before failing with error, the `frequency` (`freq`) is tested to see if it's a valid _cron string_ valid by `new CronJob (freq);`.
  - If valid, we can go ahead with `agenda.every(freq, ...)` and [agenda](https://github.com/rschmukler/agenda)  takes care of the cron string. 
  - If not valid, we catch the error thrown and go ahead with the usual way of failing with error. 

NOTE: Please don't mind the white space deletions. My editor deleted the unnecessary whitespaces and I agree with my editor.
