### PR TITLE
[feature] Run jobs only in worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ a
 
 This hook has been tested with sails 0.12.3
 
+## Fork changes:
+
+ Added enviromentToRunIn to prevent running jobs in the main process.
+
 ## Install
 
     npm install sails-hook-jobs
@@ -42,7 +46,8 @@ Copy this configurations file and save it to config/jobs.js
       "processEvery": "10 seconds",
       "maxConcurrency": 20,
       "defaultConcurrency": 5,
-      "defaultLockLifetime": 10000
+      "defaultLockLifetime": 10000,
+      "enviromentToRunIn": "JOBS_RUNNER"
     };
 
 ## How to define and schedule jobs

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(sails) {
         "defaultConcurrency": 5,
         "defaultLockLifetime": 10000,
         // enables run this hook only inside a separete worker.
-        // "enviroment_to_runin": 'JOBS_RUNNER'
+        // "enviromentToRunIn": 'JOBS_RUNNER'
       }
     },
 
@@ -58,7 +58,7 @@ module.exports = function(sails) {
         });
       };
 
-      if (config.enviroment_to_runin && sails.config.environment == config.enviroment_to_runin) {
+      if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
         sails.on("lower", stopServer);
         sails.on("lowering", stopServer);
       }
@@ -102,7 +102,7 @@ module.exports = function(sails) {
 
         sails.after(eventsToWaitFor, function(){
 
-        if (config.enviroment_to_runin && sails.config.environment == config.enviroment_to_runin) {
+        if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
           // start agenda
           agenda.start();
           sails.log.verbose("sails jobs started");

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(sails) {
         });
       };
 
-      if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
+      if (config.enviromentToRunIn && process.env.NODE_ENV == config.enviromentToRunIn) {
         sails.on("lower", stopServer);
         sails.on("lowering", stopServer);
       }
@@ -103,8 +103,8 @@ module.exports = function(sails) {
         sails.after(eventsToWaitFor, function(){
 
           sails.log.verbose('sails hooks event finished ');
-          sails.log.verbose('sails enviroment: ', sails.config.environment);
-          if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
+          sails.log.verbose('sails enviroment: ', process.env.NODE_ENV);
+          if (config.enviromentToRunIn && process.env.NODE_ENV == config.enviromentToRunIn) {
             // start agenda
             agenda.start();
             sails.log.verbose("sails jobs started");

--- a/index.js
+++ b/index.js
@@ -102,11 +102,13 @@ module.exports = function(sails) {
 
         sails.after(eventsToWaitFor, function(){
 
-        if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
-          // start agenda
-          agenda.start();
-          sails.log.verbose("sails jobs started");
-        }
+          sails.log.verbose('sails hooks event finished ');
+          sails.log.verbose('sails enviroment: ', sails.config.environment);
+          if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
+            // start agenda
+            agenda.start();
+            sails.log.verbose("sails jobs started");
+          }
 
           // Now we will return the callback and our hook
           // will be usable.

--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ module.exports = function(sails) {
         "maxConcurrency": 20,
         "defaultConcurrency": 5,
         "defaultLockLifetime": 10000,
+        // enables run this hook only inside a separete worker.
+        // "enviroment_to_runin": 'JOBS_RUNNER'
       }
     },
 
@@ -56,8 +58,10 @@ module.exports = function(sails) {
         });
       };
 
-      sails.on("lower", stopServer);
-      sails.on("lowering", stopServer);
+      if (config.enviroment_to_runin && sails.config.environment == config.enviroment_to_runin) {
+        sails.on("lower", stopServer);
+        sails.on("lowering", stopServer);
+      }
 
       // Enable jobs using coffeescript
       try {
@@ -98,11 +102,11 @@ module.exports = function(sails) {
 
         sails.after(eventsToWaitFor, function(){
 
-//        if (jobs.length > 0) {
+        if (config.enviroment_to_runin && sails.config.environment == config.enviroment_to_runin) {
           // start agenda
           agenda.start();
           sails.log.verbose("sails jobs started");
-//        }
+        }
 
           // Now we will return the callback and our hook
           // will be usable.

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(sails) {
         });
       };
 
-      if (config.enviromentToRunIn && process.env.NODE_ENV == config.enviromentToRunIn) {
+      if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
         sails.on("lower", stopServer);
         sails.on("lowering", stopServer);
       }
@@ -101,10 +101,7 @@ module.exports = function(sails) {
           eventsToWaitFor.push('hook:pubsub:loaded');
 
         sails.after(eventsToWaitFor, function(){
-
-          sails.log.verbose('sails hooks event finished ');
-          sails.log.verbose('sails enviroment: ', process.env.NODE_ENV);
-          if (config.enviromentToRunIn && process.env.NODE_ENV == config.enviromentToRunIn) {
+          if (config.enviromentToRunIn && sails.config.environment == config.enviromentToRunIn) {
             // start agenda
             agenda.start();
             sails.log.verbose("sails jobs started");


### PR DESCRIPTION
Add feature to run jobs only in worker that has NODE_ENV that is equal to the config "enviroment_to_runin". Only when enviroment_to_runin is defined.